### PR TITLE
X509 v3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit",
     "source.organizeImports": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/CHANGELOG-ja.md
+++ b/CHANGELOG-ja.md
@@ -4,6 +4,22 @@
 
 変更履歴の形式は[Keep a Changelog](https://keepachangelog.com/en/1.0.0/)に基づいています。
 
+## [2.0.5] - 2025-04-17
+
+**マイルストーン**: メインネット(1.0.3.8)
+
+| パッケージ       | バージョン | リンク                                                            |
+| ---------------- | ---------- | ----------------------------------------------------------------- |
+| Symbol Bootstrap | v2.0.5     | [symbol-bootstrap](https://github.com/nemneshia/symbol-bootstrap) |
+
+- ノード証明書を x509v3 に変更  
+  CA 証明書から作り直す必要があるので、`cert` ディレクトリを削除して再生成する必要があります。
+
+  ```bash
+  rm -rf target/nodes/node/cert
+  sb config -c custom-preset.yaml --upgrade
+  ```
+
 ## [2.0.4] - 2025-04-10
 
 **マイルストーン**: メインネット(1.0.3.8)

--- a/CHANGELOG-ja.md
+++ b/CHANGELOG-ja.md
@@ -23,15 +23,15 @@
 - Metal デコードを無効化可能に変更
 
   ```yaml
-  restMetal: null
+  metal: null
   ```
 
   なお、キャッシュサイズの変更方法は以下の通りです。
 
   ```yaml
-  restMetal:
-    restMetalCacheTtl: 350
-    restMetalSizeLimit: 15000000
+  metal:
+    cacheTtl: 350
+    sizeLimit: 15000000
   ```
 
 ## [2.0.4] - 2025-04-10

--- a/CHANGELOG-ja.md
+++ b/CHANGELOG-ja.md
@@ -20,6 +20,20 @@
   sb config -c custom-preset.yaml --upgrade
   ```
 
+- Metal デコードを無効化可能に変更
+
+  ```yaml
+  restMetal: null
+  ```
+
+  なお、キャッシュサイズの変更方法は以下の通りです。
+
+  ```yaml
+  restMetal:
+    restMetalCacheTtl: 350
+    restMetalSizeLimit: 15000000
+  ```
+
 ## [2.0.4] - 2025-04-10
 
 **マイルストーン**: メインネット(1.0.3.8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,15 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 - Made it possible to disable Metal decoding
 
   ```yaml
-  restMetal: null
+  metal: null
   ```
 
   Additionally, the method to change the cache size is as follows:
 
   ```yaml
-  restMetal:
-    restMetalCacheTtl: 350
-    restMetalSizeLimit: 15000000
+  metal:
+    cacheTtl: 350
+    sizeLimit: 15000000
   ```
 
 ## [2.0.4] - 2025-04-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
   sb config -c custom-preset.yaml --upgrade
   ```
 
+- Made it possible to disable Metal decoding
+
+  ```yaml
+  restMetal: null
+  ```
+
+  Additionally, the method to change the cache size is as follows:
+
+  ```yaml
+  restMetal:
+    restMetalCacheTtl: 350
+    restMetalSizeLimit: 15000000
+  ```
+
 ## [2.0.4] - 2025-04-10
 
 **Milestone**: Mainnet(1.0.3.8)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.0.5] - 2025-04-17
+
+**Milestone**: Mainnet(1.0.3.8)
+
+| Package          | Version | Link                                                              |
+| ---------------- | ------- | ----------------------------------------------------------------- |
+| Symbol Bootstrap | v2.0.5  | [symbol-bootstrap](https://github.com/nemneshia/symbol-bootstrap) |
+
+- Changed node certificates to x509v3.  
+  Since it is necessary to recreate them from the CA certificate, you need to delete the `cert` directory and regenerate it.
+
+  ```bash
+  rm -rf target/nodes/node/cert
+  sb config -c custom-preset.yaml --upgrade
+  ```
+
 ## [2.0.4] - 2025-04-10
 
 **Milestone**: Mainnet(1.0.3.8)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $ npm install -g @nemneshia/symbol-bootstrap
 $ symbol-bootstrap COMMAND
 running command...
 $ symbol-bootstrap (--version)
-@nemneshia/symbol-bootstrap/2.0.4 win32-x64 node-v22.14.0
+@nemneshia/symbol-bootstrap/2.0.5 win32-x64 node-v22.14.0
 $ symbol-bootstrap --help [COMMAND]
 USAGE
   $ symbol-bootstrap COMMAND

--- a/config/cert/ca.cnf.mustache
+++ b/config/cert/ca.cnf.mustache
@@ -3,20 +3,30 @@ default_ca = CA_default
 
 [CA_default]
 new_certs_dir = ./new_certs
-database = index.txt
-serial   = serial.dat
 
+database = index.txt
+serial = serial.dat
 private_key = ca.key.pem
 certificate = ca.cert.pem
-
 policy = policy_catapult
 
 [policy_catapult]
-commonName              = supplied
+commonName = supplied
 
 [req]
 prompt = no
 distinguished_name = dn
+x509_extensions = x509_v3_ca
 
 [dn]
 CN = {{{name}}}-account
+
+[x509_v3_ca]
+basicConstraints = critical,CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+
+[x509_v3_node]
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer

--- a/config/cert/node.cnf.mustache
+++ b/config/cert/node.cnf.mustache
@@ -4,4 +4,3 @@ distinguished_name = dn
 
 [dn]
 CN = {{{name}}}
-

--- a/config/rest-gateway/rest.json.mustache
+++ b/config/rest-gateway/rest.json.mustache
@@ -85,8 +85,5 @@
 
   "nodeMetadata": {{{toJson restNodeMetadata}}},
 
-  "metal": {
-    "cacheTtl": {{restMetalCacheTtl}},
-    "sizeLimit": {{restMetalSizeLimit}}
-  }
+  "metal": {{{toJson metal}}}
 }

--- a/docs/clean.md
+++ b/docs/clean.md
@@ -26,4 +26,4 @@ EXAMPLES
   $ symbol-bootstrap clean
 ```
 
-_See code: [src/commands/clean/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/clean/index.ts)_
+_See code: [src/commands/clean/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/clean/index.ts)_

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -37,4 +37,4 @@ EXAMPLES
   $ symbol-bootstrap compose
 ```
 
-_See code: [src/commands/compose/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/compose/index.ts)_
+_See code: [src/commands/compose/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/compose/index.ts)_

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,4 +58,4 @@ EXAMPLES
   $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap config -p testnet -a dual
 ```
 
-_See code: [src/commands/config/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/config/index.ts)_
+_See code: [src/commands/config/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/config/index.ts)_

--- a/docs/decrypt.md
+++ b/docs/decrypt.md
@@ -57,4 +57,4 @@ EXAMPLES
   $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml
 ```
 
-_See code: [src/commands/decrypt/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/decrypt/index.ts)_
+_See code: [src/commands/decrypt/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/decrypt/index.ts)_

--- a/docs/encrypt.md
+++ b/docs/encrypt.md
@@ -47,4 +47,4 @@ EXAMPLES
    $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap encrypt --source plain-custom-preset.yml --destination encrypted-custom-preset.yml
 ```
 
-_See code: [src/commands/encrypt/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/encrypt/index.ts)_
+_See code: [src/commands/encrypt/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/encrypt/index.ts)_

--- a/docs/healthCheck.md
+++ b/docs/healthCheck.md
@@ -41,4 +41,4 @@ EXAMPLES
   $ symbol-bootstrap healthCheck
 ```
 
-_See code: [src/commands/healthCheck/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/healthCheck/index.ts)_
+_See code: [src/commands/healthCheck/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/healthCheck/index.ts)_

--- a/docs/link.md
+++ b/docs/link.md
@@ -53,4 +53,4 @@ EXAMPLES
   $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap link --unlink --useKnownRestGateways
 ```
 
-_See code: [src/commands/link/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/link/index.ts)_
+_See code: [src/commands/link/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/link/index.ts)_

--- a/docs/modifyMultisig.md
+++ b/docs/modifyMultisig.md
@@ -58,4 +58,4 @@ EXAMPLES
   $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap modifyMultisig --useKnownRestGateways
 ```
 
-_See code: [src/commands/modifyMultisig/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/modifyMultisig/index.ts)_
+_See code: [src/commands/modifyMultisig/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/modifyMultisig/index.ts)_

--- a/docs/pack.md
+++ b/docs/pack.md
@@ -57,4 +57,4 @@ EXAMPLES
   $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap pack -c custom-preset.yml
 ```
 
-_See code: [src/commands/pack/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/pack/index.ts)_
+_See code: [src/commands/pack/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/pack/index.ts)_

--- a/docs/renewCertificates.md
+++ b/docs/renewCertificates.md
@@ -53,4 +53,4 @@ EXAMPLES
   $ symbol-bootstrap renewCertificates
 ```
 
-_See code: [src/commands/renewCertificates/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/renewCertificates/index.ts)_
+_See code: [src/commands/renewCertificates/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/renewCertificates/index.ts)_

--- a/docs/report.md
+++ b/docs/report.md
@@ -26,4 +26,4 @@ EXAMPLES
   $ symbol-bootstrap report
 ```
 
-_See code: [src/commands/report/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/report/index.ts)_
+_See code: [src/commands/report/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/report/index.ts)_

--- a/docs/resetData.md
+++ b/docs/resetData.md
@@ -26,4 +26,4 @@ EXAMPLES
   $ symbol-bootstrap resetData
 ```
 
-_See code: [src/commands/resetData/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/resetData/index.ts)_
+_See code: [src/commands/resetData/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/resetData/index.ts)_

--- a/docs/run.md
+++ b/docs/run.md
@@ -62,4 +62,4 @@ EXAMPLES
   $ symbol-bootstrap run
 ```
 
-_See code: [src/commands/run/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/run/index.ts)_
+_See code: [src/commands/run/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/run/index.ts)_

--- a/docs/start.md
+++ b/docs/start.md
@@ -112,4 +112,4 @@ EXAMPLES
   $ echo "$MY_ENV_VAR_PASSWORD" | symbol-bootstrap start -p testnet -a dual
 ```
 
-_See code: [src/commands/start/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/start/index.ts)_
+_See code: [src/commands/start/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/start/index.ts)_

--- a/docs/stop.md
+++ b/docs/stop.md
@@ -27,4 +27,4 @@ EXAMPLES
   $ symbol-bootstrap stop
 ```
 
-_See code: [src/commands/stop/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/stop/index.ts)_
+_See code: [src/commands/stop/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/stop/index.ts)_

--- a/docs/updateVotingKeys.md
+++ b/docs/updateVotingKeys.md
@@ -46,4 +46,4 @@ EXAMPLES
   $ symbol-bootstrap updateVotingKeys
 ```
 
-_See code: [src/commands/updateVotingKeys/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/updateVotingKeys/index.ts)_
+_See code: [src/commands/updateVotingKeys/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/updateVotingKeys/index.ts)_

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -26,4 +26,4 @@ EXAMPLES
   $ symbol-bootstrap verify
 ```
 
-_See code: [src/commands/verify/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/verify/index.ts)_
+_See code: [src/commands/verify/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/verify/index.ts)_

--- a/docs/wizard.md
+++ b/docs/wizard.md
@@ -36,4 +36,4 @@ EXAMPLES
   $ symbol-bootstrap wizard
 ```
 
-_See code: [src/commands/wizard/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.4/src/commands/wizard/index.ts)_
+_See code: [src/commands/wizard/index.ts](https://github.com/nemneshia/symbol-bootstrap/blob/v2.0.5/src/commands/wizard/index.ts)_

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -132,6 +132,71 @@
         "index.js"
       ]
     },
+    "decrypt": {
+      "aliases": [],
+      "args": {},
+      "description": "It decrypts a yml file using the provided password. The source file can be a custom preset file, a preset.yml file or an addresses.yml.\n\nThe main use case of this command is to verify private keys in encrypted files after encrypting a custom preset or running a bootstrap command with a provided --password.",
+      "examples": [
+        "\n$ symbol-bootstrap start --password 1234 --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n$ symbol-bootstrap decrypt --password 1234 --source target/addresses.yml --destination plain-addresses.yml\n$ symbol-bootstrap decrypt --password 1234 --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml\n        ",
+        "\n$ symbol-bootstrap start --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n> password prompt\n$ symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n> password prompt (enter the same password)\n$ symbol-bootstrap decrypt --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n> password prompt (enter the same password)\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml",
+        "\n$ echo \"$MY_ENV_VAR_PASSWORD\" | symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "It shows the help of this command.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "source": {
+          "description": "The source encrypted yml file to be decrypted.",
+          "name": "source",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "destination": {
+          "description": "The destination decrypted file to create. The destination file must not exist.",
+          "name": "destination",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "The password to use to decrypt the source file into the destination file. Bootstrap prompts for a password by default, can be provided in the command line (--password=XXXX) or disabled in the command line (--noPassword).",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "logger": {
+          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
+          "name": "logger",
+          "default": "Console",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "decrypt",
+      "pluginAlias": "@nemneshia/symbol-bootstrap",
+      "pluginName": "@nemneshia/symbol-bootstrap",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "lib",
+        "commands",
+        "decrypt",
+        "index.js"
+      ]
+    },
     "config": {
       "aliases": [],
       "args": {},
@@ -319,120 +384,6 @@
         "lib",
         "commands",
         "encrypt",
-        "index.js"
-      ]
-    },
-    "decrypt": {
-      "aliases": [],
-      "args": {},
-      "description": "It decrypts a yml file using the provided password. The source file can be a custom preset file, a preset.yml file or an addresses.yml.\n\nThe main use case of this command is to verify private keys in encrypted files after encrypting a custom preset or running a bootstrap command with a provided --password.",
-      "examples": [
-        "\n$ symbol-bootstrap start --password 1234 --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n$ symbol-bootstrap decrypt --password 1234 --source target/addresses.yml --destination plain-addresses.yml\n$ symbol-bootstrap decrypt --password 1234 --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml\n        ",
-        "\n$ symbol-bootstrap start --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n> password prompt\n$ symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n> password prompt (enter the same password)\n$ symbol-bootstrap decrypt --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n> password prompt (enter the same password)\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml",
-        "\n$ echo \"$MY_ENV_VAR_PASSWORD\" | symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n"
-      ],
-      "flags": {
-        "help": {
-          "char": "h",
-          "description": "It shows the help of this command.",
-          "name": "help",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "source": {
-          "description": "The source encrypted yml file to be decrypted.",
-          "name": "source",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "destination": {
-          "description": "The destination decrypted file to create. The destination file must not exist.",
-          "name": "destination",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "password": {
-          "description": "The password to use to decrypt the source file into the destination file. Bootstrap prompts for a password by default, can be provided in the command line (--password=XXXX) or disabled in the command line (--noPassword).",
-          "name": "password",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "logger": {
-          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
-          "name": "logger",
-          "default": "Console",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "decrypt",
-      "pluginAlias": "@nemneshia/symbol-bootstrap",
-      "pluginName": "@nemneshia/symbol-bootstrap",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "lib",
-        "commands",
-        "decrypt",
-        "index.js"
-      ]
-    },
-    "healthCheck": {
-      "aliases": [],
-      "args": {},
-      "description": "It checks if the services created with docker compose are up and running.\n\nThis command checks:\n- Whether the docker containers are running.\n- Whether the services' exposed ports are listening.\n- Whether the rest gateways' /node/health are OK.\n\nThe health check process handles 'repeat' and custom 'openPort' services.\n    ",
-      "examples": [
-        "$ symbol-bootstrap healthCheck"
-      ],
-      "flags": {
-        "help": {
-          "char": "h",
-          "description": "It shows the help of this command.",
-          "name": "help",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "target": {
-          "char": "t",
-          "description": "The target folder where the symbol-bootstrap network is generated",
-          "name": "target",
-          "default": "target",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "logger": {
-          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
-          "name": "logger",
-          "default": "Console,File",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "healthCheck",
-      "pluginAlias": "@nemneshia/symbol-bootstrap",
-      "pluginName": "@nemneshia/symbol-bootstrap",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "lib",
-        "commands",
-        "healthCheck",
         "index.js"
       ]
     },
@@ -685,6 +636,55 @@
         "lib",
         "commands",
         "modifyMultisig",
+        "index.js"
+      ]
+    },
+    "healthCheck": {
+      "aliases": [],
+      "args": {},
+      "description": "It checks if the services created with docker compose are up and running.\n\nThis command checks:\n- Whether the docker containers are running.\n- Whether the services' exposed ports are listening.\n- Whether the rest gateways' /node/health are OK.\n\nThe health check process handles 'repeat' and custom 'openPort' services.\n    ",
+      "examples": [
+        "$ symbol-bootstrap healthCheck"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "It shows the help of this command.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "target": {
+          "char": "t",
+          "description": "The target folder where the symbol-bootstrap network is generated",
+          "name": "target",
+          "default": "target",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "logger": {
+          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
+          "name": "logger",
+          "default": "Console,File",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "healthCheck",
+      "pluginAlias": "@nemneshia/symbol-bootstrap",
+      "pluginName": "@nemneshia/symbol-bootstrap",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "lib",
+        "commands",
+        "healthCheck",
         "index.js"
       ]
     },
@@ -1516,5 +1516,5 @@
       ]
     }
   },
-  "version": "2.0.4"
+  "version": "2.0.5"
 }

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1,195 +1,5 @@
 {
   "commands": {
-    "decrypt": {
-      "aliases": [],
-      "args": {},
-      "description": "It decrypts a yml file using the provided password. The source file can be a custom preset file, a preset.yml file or an addresses.yml.\n\nThe main use case of this command is to verify private keys in encrypted files after encrypting a custom preset or running a bootstrap command with a provided --password.",
-      "examples": [
-        "\n$ symbol-bootstrap start --password 1234 --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n$ symbol-bootstrap decrypt --password 1234 --source target/addresses.yml --destination plain-addresses.yml\n$ symbol-bootstrap decrypt --password 1234 --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml\n        ",
-        "\n$ symbol-bootstrap start --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n> password prompt\n$ symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n> password prompt (enter the same password)\n$ symbol-bootstrap decrypt --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n> password prompt (enter the same password)\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml",
-        "\n$ echo \"$MY_ENV_VAR_PASSWORD\" | symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n"
-      ],
-      "flags": {
-        "help": {
-          "char": "h",
-          "description": "It shows the help of this command.",
-          "name": "help",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "source": {
-          "description": "The source encrypted yml file to be decrypted.",
-          "name": "source",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "destination": {
-          "description": "The destination decrypted file to create. The destination file must not exist.",
-          "name": "destination",
-          "required": true,
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "password": {
-          "description": "The password to use to decrypt the source file into the destination file. Bootstrap prompts for a password by default, can be provided in the command line (--password=XXXX) or disabled in the command line (--noPassword).",
-          "name": "password",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "logger": {
-          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
-          "name": "logger",
-          "default": "Console",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "decrypt",
-      "pluginAlias": "@nemneshia/symbol-bootstrap",
-      "pluginName": "@nemneshia/symbol-bootstrap",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "lib",
-        "commands",
-        "decrypt",
-        "index.js"
-      ]
-    },
-    "config": {
-      "aliases": [],
-      "args": {},
-      "description": "Command used to set up the configuration files and the nemesis block for the current network",
-      "examples": [
-        "$ symbol-bootstrap config -p bootstrap",
-        "$ symbol-bootstrap config -p testnet -a dual --password 1234",
-        "$ symbol-bootstrap config -p mainnet -a peer -c custom-preset.yml",
-        "$ symbol-bootstrap config -p mainnet -a my-custom-assembly.yml -c custom-preset.yml",
-        "$ symbol-bootstrap config -p my-custom-network.yml -a dual -c custom-preset.yml",
-        "$ echo \"$MY_ENV_VAR_PASSWORD\" | symbol-bootstrap config -p testnet -a dual"
-      ],
-      "flags": {
-        "help": {
-          "char": "h",
-          "description": "It shows the help of this command.",
-          "name": "help",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "target": {
-          "char": "t",
-          "description": "The target folder where the symbol-bootstrap network is generated",
-          "name": "target",
-          "default": "target",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "password": {
-          "description": "A password used to encrypt and decrypt private keys in preset files like addresses.yml and preset.yml. Bootstrap prompts for a password by default, can be provided in the command line (--password=XXXX) or disabled in the command line (--noPassword).",
-          "name": "password",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "noPassword": {
-          "description": "When provided, Bootstrap will not use a password, so private keys will be stored in plain text. Use with caution.",
-          "name": "noPassword",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "preset": {
-          "char": "p",
-          "description": "The network preset. It can be provided via custom preset or cli parameter. If not provided, the value is resolved from the target/preset.yml file. Options are: bootstrap, testnet, mainnet, my-custom-network.yml (advanced, only for custom networks).",
-          "name": "preset",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "assembly": {
-          "char": "a",
-          "description": "The assembly that defines the node(s) layout. It can be provided via custom preset or cli parameter. If not provided, the value is resolved from the target/preset.yml file. Options are: dual, peer, api, demo, multinode, services, my-custom-assembly.yml (advanced).",
-          "name": "assembly",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "customPreset": {
-          "char": "c",
-          "description": "External preset file. Values in this file will override the provided presets.",
-          "name": "customPreset",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "reset": {
-          "char": "r",
-          "description": "It resets the configuration generating a new one.",
-          "name": "reset",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "upgrade": {
-          "description": "It regenerates the configuration reusing the previous keys. Use this flag when upgrading the version of bootstrap to keep your node up to date without dropping the local data. Backup the target folder before upgrading.",
-          "name": "upgrade",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "offline": {
-          "description": "If --offline is used, Bootstrap resolves the configuration without querying the running network.",
-          "name": "offline",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "report": {
-          "description": "It generates reStructuredText (.rst) reports describing the configuration of each node.",
-          "name": "report",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "user": {
-          "char": "u",
-          "description": "User used to run docker images when creating configuration files like certificates or nemesis block. \"current\" means the current user.",
-          "name": "user",
-          "default": "current",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "logger": {
-          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
-          "name": "logger",
-          "default": "Console,File",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "config",
-      "pluginAlias": "@nemneshia/symbol-bootstrap",
-      "pluginName": "@nemneshia/symbol-bootstrap",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "lib",
-        "commands",
-        "config",
-        "index.js"
-      ]
-    },
     "clean": {
       "aliases": [],
       "args": {},
@@ -322,6 +132,131 @@
         "index.js"
       ]
     },
+    "config": {
+      "aliases": [],
+      "args": {},
+      "description": "Command used to set up the configuration files and the nemesis block for the current network",
+      "examples": [
+        "$ symbol-bootstrap config -p bootstrap",
+        "$ symbol-bootstrap config -p testnet -a dual --password 1234",
+        "$ symbol-bootstrap config -p mainnet -a peer -c custom-preset.yml",
+        "$ symbol-bootstrap config -p mainnet -a my-custom-assembly.yml -c custom-preset.yml",
+        "$ symbol-bootstrap config -p my-custom-network.yml -a dual -c custom-preset.yml",
+        "$ echo \"$MY_ENV_VAR_PASSWORD\" | symbol-bootstrap config -p testnet -a dual"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "It shows the help of this command.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "target": {
+          "char": "t",
+          "description": "The target folder where the symbol-bootstrap network is generated",
+          "name": "target",
+          "default": "target",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "A password used to encrypt and decrypt private keys in preset files like addresses.yml and preset.yml. Bootstrap prompts for a password by default, can be provided in the command line (--password=XXXX) or disabled in the command line (--noPassword).",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "noPassword": {
+          "description": "When provided, Bootstrap will not use a password, so private keys will be stored in plain text. Use with caution.",
+          "name": "noPassword",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "preset": {
+          "char": "p",
+          "description": "The network preset. It can be provided via custom preset or cli parameter. If not provided, the value is resolved from the target/preset.yml file. Options are: bootstrap, testnet, mainnet, my-custom-network.yml (advanced, only for custom networks).",
+          "name": "preset",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "assembly": {
+          "char": "a",
+          "description": "The assembly that defines the node(s) layout. It can be provided via custom preset or cli parameter. If not provided, the value is resolved from the target/preset.yml file. Options are: dual, peer, api, demo, multinode, services, my-custom-assembly.yml (advanced).",
+          "name": "assembly",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customPreset": {
+          "char": "c",
+          "description": "External preset file. Values in this file will override the provided presets.",
+          "name": "customPreset",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "char": "r",
+          "description": "It resets the configuration generating a new one.",
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "upgrade": {
+          "description": "It regenerates the configuration reusing the previous keys. Use this flag when upgrading the version of bootstrap to keep your node up to date without dropping the local data. Backup the target folder before upgrading.",
+          "name": "upgrade",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "offline": {
+          "description": "If --offline is used, Bootstrap resolves the configuration without querying the running network.",
+          "name": "offline",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "report": {
+          "description": "It generates reStructuredText (.rst) reports describing the configuration of each node.",
+          "name": "report",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "user": {
+          "char": "u",
+          "description": "User used to run docker images when creating configuration files like certificates or nemesis block. \"current\" means the current user.",
+          "name": "user",
+          "default": "current",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "logger": {
+          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
+          "name": "logger",
+          "default": "Console,File",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config",
+      "pluginAlias": "@nemneshia/symbol-bootstrap",
+      "pluginName": "@nemneshia/symbol-bootstrap",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "lib",
+        "commands",
+        "config",
+        "index.js"
+      ]
+    },
     "encrypt": {
       "aliases": [],
       "args": {},
@@ -384,6 +319,120 @@
         "lib",
         "commands",
         "encrypt",
+        "index.js"
+      ]
+    },
+    "decrypt": {
+      "aliases": [],
+      "args": {},
+      "description": "It decrypts a yml file using the provided password. The source file can be a custom preset file, a preset.yml file or an addresses.yml.\n\nThe main use case of this command is to verify private keys in encrypted files after encrypting a custom preset or running a bootstrap command with a provided --password.",
+      "examples": [
+        "\n$ symbol-bootstrap start --password 1234 --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n$ symbol-bootstrap decrypt --password 1234 --source target/addresses.yml --destination plain-addresses.yml\n$ symbol-bootstrap decrypt --password 1234 --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml\n        ",
+        "\n$ symbol-bootstrap start --preset testnet --assembly dual --customPreset decrypted-custom-preset.yml --detached\n> password prompt\n$ symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n> password prompt (enter the same password)\n$ symbol-bootstrap decrypt --source encrypted-custom-preset.yml --destination plain-custom-preset.yml\n> password prompt (enter the same password)\n$ cat plain-addresses.yml\n$ cat plain-custom-preset.yml\n$ rm plain-addresses.yml\n$ rm plain-custom-preset.yml",
+        "\n$ echo \"$MY_ENV_VAR_PASSWORD\" | symbol-bootstrap decrypt --source target/addresses.yml --destination plain-addresses.yml\n"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "It shows the help of this command.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "source": {
+          "description": "The source encrypted yml file to be decrypted.",
+          "name": "source",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "destination": {
+          "description": "The destination decrypted file to create. The destination file must not exist.",
+          "name": "destination",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "The password to use to decrypt the source file into the destination file. Bootstrap prompts for a password by default, can be provided in the command line (--password=XXXX) or disabled in the command line (--noPassword).",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "logger": {
+          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
+          "name": "logger",
+          "default": "Console",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "decrypt",
+      "pluginAlias": "@nemneshia/symbol-bootstrap",
+      "pluginName": "@nemneshia/symbol-bootstrap",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "lib",
+        "commands",
+        "decrypt",
+        "index.js"
+      ]
+    },
+    "healthCheck": {
+      "aliases": [],
+      "args": {},
+      "description": "It checks if the services created with docker compose are up and running.\n\nThis command checks:\n- Whether the docker containers are running.\n- Whether the services' exposed ports are listening.\n- Whether the rest gateways' /node/health are OK.\n\nThe health check process handles 'repeat' and custom 'openPort' services.\n    ",
+      "examples": [
+        "$ symbol-bootstrap healthCheck"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "It shows the help of this command.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "target": {
+          "char": "t",
+          "description": "The target folder where the symbol-bootstrap network is generated",
+          "name": "target",
+          "default": "target",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "logger": {
+          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
+          "name": "logger",
+          "default": "Console,File",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "healthCheck",
+      "pluginAlias": "@nemneshia/symbol-bootstrap",
+      "pluginName": "@nemneshia/symbol-bootstrap",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "lib",
+        "commands",
+        "healthCheck",
         "index.js"
       ]
     },
@@ -497,55 +546,6 @@
         "lib",
         "commands",
         "link",
-        "index.js"
-      ]
-    },
-    "healthCheck": {
-      "aliases": [],
-      "args": {},
-      "description": "It checks if the services created with docker compose are up and running.\n\nThis command checks:\n- Whether the docker containers are running.\n- Whether the services' exposed ports are listening.\n- Whether the rest gateways' /node/health are OK.\n\nThe health check process handles 'repeat' and custom 'openPort' services.\n    ",
-      "examples": [
-        "$ symbol-bootstrap healthCheck"
-      ],
-      "flags": {
-        "help": {
-          "char": "h",
-          "description": "It shows the help of this command.",
-          "name": "help",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "target": {
-          "char": "t",
-          "description": "The target folder where the symbol-bootstrap network is generated",
-          "name": "target",
-          "default": "target",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "logger": {
-          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
-          "name": "logger",
-          "default": "Console,File",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "healthCheck",
-      "pluginAlias": "@nemneshia/symbol-bootstrap",
-      "pluginName": "@nemneshia/symbol-bootstrap",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "lib",
-        "commands",
-        "healthCheck",
         "index.js"
       ]
     },
@@ -1271,6 +1271,55 @@
         "index.js"
       ]
     },
+    "stop": {
+      "aliases": [],
+      "args": {},
+      "description": "It stops the docker compose network if running (symbol-bootstrap started with --detached). This is just a wrapper for the `docker compose down` bash call.",
+      "examples": [
+        "$ symbol-bootstrap stop"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "It shows the help of this command.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "target": {
+          "char": "t",
+          "description": "The target folder where the symbol-bootstrap network is generated",
+          "name": "target",
+          "default": "target",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "logger": {
+          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
+          "name": "logger",
+          "default": "Console,File",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "stop",
+      "pluginAlias": "@nemneshia/symbol-bootstrap",
+      "pluginName": "@nemneshia/symbol-bootstrap",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "isESM": true,
+      "relativePath": [
+        "lib",
+        "commands",
+        "stop",
+        "index.js"
+      ]
+    },
     "updateVotingKeys": {
       "aliases": [],
       "args": {},
@@ -1333,55 +1382,6 @@
         "lib",
         "commands",
         "updateVotingKeys",
-        "index.js"
-      ]
-    },
-    "stop": {
-      "aliases": [],
-      "args": {},
-      "description": "It stops the docker compose network if running (symbol-bootstrap started with --detached). This is just a wrapper for the `docker compose down` bash call.",
-      "examples": [
-        "$ symbol-bootstrap stop"
-      ],
-      "flags": {
-        "help": {
-          "char": "h",
-          "description": "It shows the help of this command.",
-          "name": "help",
-          "allowNo": false,
-          "type": "boolean"
-        },
-        "target": {
-          "char": "t",
-          "description": "The target folder where the symbol-bootstrap network is generated",
-          "name": "target",
-          "default": "target",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        },
-        "logger": {
-          "description": "The loggers the command will use. Options are: Console,File,Silent. Use ',' to select multiple loggers.",
-          "name": "logger",
-          "default": "Console,File",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [],
-      "id": "stop",
-      "pluginAlias": "@nemneshia/symbol-bootstrap",
-      "pluginName": "@nemneshia/symbol-bootstrap",
-      "pluginType": "core",
-      "strict": true,
-      "enableJsonFlag": false,
-      "isESM": true,
-      "relativePath": [
-        "lib",
-        "commands",
-        "stop",
         "index.js"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nemneshia/symbol-bootstrap",
   "description": "Symbol tool that allows you creating, configuring and running Symbol's networks",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "author": "Nemneshia <@nemneshia>",
   "type": "module",
   "bin": {

--- a/presets/mainnet/network.yml
+++ b/presets/mainnet/network.yml
@@ -27,7 +27,7 @@ minVotingKeyLifetime: 112
 maxVotingKeyLifetime: 360
 votingKeyDesiredLifetime: 360
 votingKeyDesiredFutureLifetime: 60
-lastKnownNetworkEpoch: 2972
+lastKnownNetworkEpoch: 2982
 stepDuration: 5m
 maxBlockFutureTime: 300ms
 maxAccountRestrictionValues: 100

--- a/presets/mainnet/network.yml
+++ b/presets/mainnet/network.yml
@@ -27,7 +27,7 @@ minVotingKeyLifetime: 112
 maxVotingKeyLifetime: 360
 votingKeyDesiredLifetime: 360
 votingKeyDesiredFutureLifetime: 60
-lastKnownNetworkEpoch: 2982
+lastKnownNetworkEpoch: 2984
 stepDuration: 5m
 maxBlockFutureTime: 300ms
 maxAccountRestrictionValues: 100

--- a/presets/shared.yml
+++ b/presets/shared.yml
@@ -235,8 +235,9 @@ restSSLKeyFileName: 'restSSL.key'
 restSSLCertificateFileName: 'restSSL.crt'
 restNodeMetadata:
   _info: 'Node metadata'
-restMetalCacheTtl: 300
-restMetalSizeLimit: 10000000
+metal:
+  cacheTtl: 300
+  sizeLimit: 10000000
 statisticsServicePeerFilter: ''
 statisticsServicePeerLimit: 50
 statisticsServiceRestFilter: suggested

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -22,7 +22,7 @@ importanceGrouping: 180
 votingSetGrouping: 720
 votingKeyDesiredLifetime: 720
 votingKeyDesiredFutureLifetime: 120
-lastKnownNetworkEpoch: 3192
+lastKnownNetworkEpoch: 2984
 minVotingKeyLifetime: 28
 maxVotingKeyLifetime: 720
 stepDuration: 4m

--- a/presets/testnet/network.yml
+++ b/presets/testnet/network.yml
@@ -22,7 +22,7 @@ importanceGrouping: 180
 votingSetGrouping: 720
 votingKeyDesiredLifetime: 720
 votingKeyDesiredFutureLifetime: 120
-lastKnownNetworkEpoch: 2972
+lastKnownNetworkEpoch: 3192
 minVotingKeyLifetime: 28
 maxVotingKeyLifetime: 720
 stepDuration: 4m

--- a/src/model/ConfigPreset.ts
+++ b/src/model/ConfigPreset.ts
@@ -324,8 +324,10 @@ export interface GatewayConfigPreset {
   restSSLCertificateFileName: string;
   restSSLKeyBase64?: string;
   restSSLCertificateBase64?: string;
-  restMetalCacheTtl: number;
-  restMetalSizeLimit: number;
+  metal: {
+    cacheTtl: number;
+    sizeLimit: number;
+  };
 }
 
 export interface GatewayPreset extends DockerServicePreset, Partial<GatewayConfigPreset> {

--- a/src/service/CertificateService.ts
+++ b/src/service/CertificateService.ts
@@ -224,10 +224,10 @@ export class CertificateService {
 
   private createCertCommands(renew: boolean, caCertificateExpirationInDays: number, nodeCertificateExpirationInDays: number): string {
     const createCaCertificate = renew
-      ? `openssl x509 -in ${CertificateService.CA_CERTIFICATE_FILE_NAME}  -text -noout`
+      ? `openssl x509 -in ${CertificateService.CA_CERTIFICATE_FILE_NAME} -text -noout`
       : `# create CA cert and self-sign it
-    openssl req -config ca.cnf -keyform PEM -key ca.key.pem -new -x509 -days ${caCertificateExpirationInDays} -out ${CertificateService.CA_CERTIFICATE_FILE_NAME}
-    openssl x509 -in ${CertificateService.CA_CERTIFICATE_FILE_NAME}  -text -noout
+    openssl req -config ca.cnf -keyform PEM -key ca.key.pem -new -x509 -days ${caCertificateExpirationInDays} -out ${CertificateService.CA_CERTIFICATE_FILE_NAME} -extensions x509_v3_ca
+    openssl x509 -in ${CertificateService.CA_CERTIFICATE_FILE_NAME} -text -noout
     `;
     return `set -e
 
@@ -256,13 +256,13 @@ openssl pkey -inform pem -in node.key.pem -text -noout
 
 # create request
 openssl req -config node.cnf -key node.key.pem -new -out node.csr.pem
-openssl req  -text -noout -verify -in node.csr.pem
+openssl req -text -noout -verify -in node.csr.pem
 
 ### below is done after files are written
 # CA side
 
 # sign cert for 375 days
-openssl ca -batch -config ca.cnf -days ${nodeCertificateExpirationInDays} -notext -in node.csr.pem -out ${CertificateService.NODE_CERTIFICATE_FILE_NAME}
+openssl ca -batch -config ca.cnf -days ${nodeCertificateExpirationInDays} -notext -in node.csr.pem -out ${CertificateService.NODE_CERTIFICATE_FILE_NAME} -extensions x509_v3_node
 openssl verify -CAfile ${CertificateService.CA_CERTIFICATE_FILE_NAME} ${CertificateService.NODE_CERTIFICATE_FILE_NAME}
 
 # finally create full crt


### PR DESCRIPTION
## [2.0.5] - 2025-04-17

**マイルストーン**: メインネット(1.0.3.8)

| パッケージ       | バージョン | リンク                                                            |
| ---------------- | ---------- | ----------------------------------------------------------------- |
| Symbol Bootstrap | v2.0.5     | [symbol-bootstrap](https://github.com/nemneshia/symbol-bootstrap) |

- ノード証明書を x509v3 に変更  
  CA 証明書から作り直す必要があるので、`cert` ディレクトリを削除して再生成する必要があります。

  ```bash
  rm -rf target/nodes/node/cert
  sb config -c custom-preset.yaml --upgrade
  ```

- Metal デコードを無効化可能に変更

  ```yaml
  metal: null
  ```

  なお、キャッシュサイズの変更方法は以下の通りです。

  ```yaml
  metal:
    cacheTtl: 350
    sizeLimit: 15000000
  ```